### PR TITLE
[WIP] Enhanced condition checks & events gathering

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -8,6 +8,13 @@ import (
 	"github.com/slack-go/slack"
 )
 
+// color codes for slack message
+const (
+	OrangeColor = "#e69500" // Rollout Started
+	GreenColor  = "#36a64f" // Rollout Successful
+	RedColor    = "#e60000" // Rollout Failed
+)
+
 // This package will consists of code which will make slack API call to post a message
 type Client struct {
 	client *slack.Client
@@ -23,13 +30,32 @@ func NewClient() (*Client, error) {
 	return &Client{client: slack.New(token)}, nil
 }
 
-func (c *Client) SendMessage(channel, message string) error {
+func (c *Client) SendMessage(channel, message, color string) error {
 	log.Debugf("sending alert \"%s\" to '%s'", message, channel)
 
-	_, _, err := c.client.PostMessage(channel, slack.MsgOptionText(message, false))
+	_, _, err := c.client.PostMessage(channel, slack.MsgOptionAttachments(createSlackAttachment(message, color)))
+
 	if err != nil {
 		return fmt.Errorf("failed to send message \"%s\" to '%s': %s", message, channel, err)
 	}
 
 	return err
+}
+
+func createSlackAttachment(msg, color string) slack.Attachment {
+
+	attachment := slack.Attachment{
+		Footer: "hermod",
+		Fields: []slack.AttachmentField{
+			{
+				Value: msg,
+			},
+		},
+	}
+
+	attachment.Color = color
+
+	attachment.MarkdownIn = []string{"fields"}
+
+	return attachment
 }


### PR DESCRIPTION
There are major 4 conditions in the control loop:

* [Rollout Started](https://github.com/uswitch/hermod/pull/3/files#diff-54a50df0dc2d5c7941350ca5daf83143cb7e0fba51b2590881b7b2e2ae4df12aR57)
  * decided when different revision number is detected
  * remove the hermod annotation
* [Rollout Successful](https://github.com/uswitch/hermod/pull/3/files#diff-54a50df0dc2d5c7941350ca5daf83143cb7e0fba51b2590881b7b2e2ae4df12aR66)
   * decided when given conditions are met
   * add hermod annotation (pass) 
* [Do nothing](https://github.com/uswitch/hermod/pull/3/files#diff-54a50df0dc2d5c7941350ca5daf83143cb7e0fba51b2590881b7b2e2ae4df12aR53)
   * if resource version are same  
* [Rollout Failure](https://github.com/uswitch/hermod/pull/3/files#diff-54a50df0dc2d5c7941350ca5daf83143cb7e0fba51b2590881b7b2e2ae4df12aR79)
   * Once the failure is detected based on `ProgressDeadlineExceeded` condition, it will find it's respective replicaset and pods
   * if there are no pods we will get  the find the errors from replicaset itself
   * if there are any errors we will get the errors from cotainerStatuses & initContainerStatuses fields in the podStatus  


Future TODO:
* as of now we list replicaset and pods with direct List call, but we can replace it with Listers