### PR TITLE
AIRSHIP-372 - Use watcher to have cache of namespaces to fetch slack channel annotation

### DIFF
--- a/pkg/kubernetes/watch_deployment.go
+++ b/pkg/kubernetes/watch_deployment.go
@@ -26,8 +26,8 @@ type deploymentInformer struct {
 }
 
 const (
-	SLACK_CHANNEL_ANNOTATION = "com.uswitch.hermod/slack"
-	revision                 = "deployment.kubernetes.io/revision"
+	slackChannelAnnotation = "com.uswitch.hermod/slack"
+	revision               = "deployment.kubernetes.io/revision"
 )
 
 func NewDeploymentWatcher(client *kubernetes.Clientset) *deploymentInformer {
@@ -101,7 +101,7 @@ func getSlackChannel(namespace string, indexer cache.Indexer) string {
 	nsAnnotations, _ := meta.NewAccessor().Annotations(nsResource.(runtime.Object))
 
 	for k, v := range nsAnnotations {
-		if k == SLACK_CHANNEL_ANNOTATION {
+		if k == slackChannelAnnotation {
 			return v
 		}
 	}


### PR DESCRIPTION
Followed similar pattern to Klint - 
- Have a watcher on namespaces - https://github.com/uswitch/klint/blob/master/engine/engine.go#L45-L57
- Retrieve annotations - https://github.com/uswitch/klint/blob/master/engine/engine.go#L141-L146 and  https://github.com/uswitch/klint/blob/master/engine/engine.go#L117-L125

This saves us having to perform an API call every time we enter in to a cycle.
