### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+FROM alpine:3.12 AS builder
+
+RUN apk --update add ca-certificates
+
 FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ADD bin/hermod-linux-amd64 hermod
 


### PR DESCRIPTION
hermod image with scratch base was failing with cert error as shown below, this PR filx that by adding multistage build to add the certs
```
{"level":"error","msg":"failed to send slack message: failed to send message \"Rolling out Deployment `nginx` in namespace `default`.\" to 'k8s-events-test-2': Post \"https://slack.com/api/chat.postMessage\": x509: certificate signed by unknown authority","time":"2021-07-07T10:01:33Z"}
```