### PR TITLE
Fix the label to fetch the replicaset

### DIFF
--- a/pkg/kubernetes/watch_deployment.go
+++ b/pkg/kubernetes/watch_deployment.go
@@ -196,9 +196,10 @@ func getSlackChannel(namespace string, indexer cache.Indexer) string {
 
 func getErrorEvents(ctx context.Context, client *kubernetes.Clientset, namespace string, newDeployment *appsv1.Deployment) (string, error) {
 
-	// Get Deployment Labels
-	deploymentLabels := newDeployment.GetLabels()
-	labelSelector := labels.FormatLabels(deploymentLabels)
+	// Get Pod Labels
+	podLabels := newDeployment.Spec.Template.Labels
+
+	labelSelector := labels.FormatLabels(podLabels)
 
 	// Find Replicaset based on labels and given revision in annotation
 	rs, err := getReplicaSet(ctx, client, namespace, labelSelector, newDeployment.Annotations[revision])


### PR DESCRIPTION
Ideally we should compare the labels from the pods and not the deployment, especially it failed for customer platform is because there were no labels on the deployments.