### PR TITLE
Fix the empty errors

### DIFF
--- a/pkg/kubernetes/watch_deployment.go
+++ b/pkg/kubernetes/watch_deployment.go
@@ -249,7 +249,7 @@ func getErrorEvents(ctx context.Context, client *kubernetes.Clientset, namespace
 
 	// delayed rollout
 	if len(errorList) == 0 {
-		errorText := fmt.Sprintf("Rollout for Deployment `%s` (RS: `%s`) in `%s` namespace is taking longer than `%v` seconds on the `%s` cluster.\n", newDeployment.Name, rs.Name, newDeployment.Namespace, *newDeployment.Spec.ProgressDeadlineSeconds, getClusterName())
+		errorText := fmt.Sprintf("Deployment `%s` (RS: `%s`) in `%s` namespace failed to reach desired replicas within `%v` seconds on the `%s` cluster, only `%v/%v` replicas are ready.\n", newDeployment.Name, rs.Name, newDeployment.Namespace, *newDeployment.Spec.ProgressDeadlineSeconds, getClusterName(), newDeployment.Status.ReadyReplicas, *newDeployment.Spec.Replicas)
 		return errorText, nil
 	}
 


### PR DESCRIPTION
Scenario: 

When deployment takes more time than progressDeadlineSeconds, there's no error either on Replicaset or on Containers, hence there was an empty list of errors.

This PR will show different message if there's empty errors,


```
Rollout for Deployment nginx (RS: nginx-75f4db9b65) in hermod-testing namespace is taking longer than 6 seconds on the minikube cluster.
```

Rest functionality remains the same.