### PR TITLE
Fix hermod annotation error

### DIFF
--- a/pkg/kubernetes/watch_deployment.go
+++ b/pkg/kubernetes/watch_deployment.go
@@ -317,8 +317,6 @@ func getPods(ctx context.Context, client kubernetes.Interface, namespace string,
 
 // addAnnotation will add the hermod specific annotation to the deployment
 func addAnnotation(ctx context.Context, client *kubernetes.Clientset, namespace string, newDeployment *appsv1.Deployment, state string) error {
-	// ann := newDeployment.ObjectMeta.Annotations
-	// ann[hermodAnnotation] = state
 
 	patch := map[string]interface{}{
 		"metadata": map[string]map[string]string{
@@ -331,10 +329,7 @@ func addAnnotation(ctx context.Context, client *kubernetes.Clientset, namespace 
 		return fmt.Errorf("error marshalling data to json: %v", err)
 	}
 
-	// newDeployment.ObjectMeta.Annotations = ann
-	// newDeployment.ObjectMeta.ResourceVersion = ""
 	_, err = client.AppsV1().Deployments(namespace).Patch(ctx, newDeployment.Name, types.MergePatchType, marshalledPatch, metav1.PatchOptions{})
-	// _, err := client.AppsV1().Deployments(namespace).Update(ctx, newDeployment, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hermod was not delivering success/failure alerts to user's slack as it was unable to annotate the deployment with following error.

```
{"level":"error","msg":"failed to add annotation: Operation cannot be fulfilled on deployments.apps \"mobile-app-api-staging\": the object has been modified; please apply your changes to the latest version and try again","time":"2021-10-26T09:43:52Z"}
```

Potential reason could be we are doing Update call in which we were trying to update the deployment object whereas resourceVersion must have changed because of various reasons (probably by other controllers)

With this PR, we are adding patch call instead of update call for annotating the deployment, I've tested this solution and this seems to be solving the issue.