### PR TITLE
Fix prometheus metric

### DIFF
--- a/pkg/kubernetes/watch_deployment.go
+++ b/pkg/kubernetes/watch_deployment.go
@@ -127,9 +127,9 @@ func (b *deploymentInformer) OnUpdate(old, new interface{}) {
 				log.Errorf(message)
 				sentry.CaptureMessage(message)
 			}
-			return
 		}
 		deploymentProcessedTotal.Inc()
+		return
 	}
 
 	// Get the DeploymentCondition and sort them based on time


### PR DESCRIPTION
Fixing when to publish `hermod_deployment_processed_total` metric. This currently is only incremented if hermod is configured to notify of deployment failures.

