### PR TITLE
Update message wording in Hermod and fix a test

### DIFF
--- a/pkg/kubernetes/watch_deployment.go
+++ b/pkg/kubernetes/watch_deployment.go
@@ -157,7 +157,7 @@ func (b *deploymentInformer) OnUpdate(old, new interface{}) {
 				log.Errorf("failed to add annotation: %v", err)
 			}
 
-			msg := fmt.Sprintf("*Rollout for Deployment `%s` in `%s` namespace on `%s` cluster is successful.*", deploymentNew.Name, deploymentNew.Namespace, getClusterName())
+			msg := fmt.Sprintf("*Rollout for Deployment `%s` in namespace `%s` on `%s` cluster is successful.*", deploymentNew.Name, deploymentNew.Namespace, getClusterName())
 			log.Infof(msg)
 
 			// Send message if alertLevel isn't set to Failure only

--- a/pkg/kubernetes/watch_deployment_test.go
+++ b/pkg/kubernetes/watch_deployment_test.go
@@ -252,7 +252,7 @@ func TestGetErrorEvents(t *testing.T) {
 	}
 	client := k8sfake.NewSimpleClientset(&podo, &deployment, &rs)
 
-	outputString := fmt.Sprintf("*Rollout for Deployment `test` (RS: `test`) in `test` namespace failed after `10` seconds on the `` cluster.*\n\n*Retrieved the following errors:*\n```\n* InitContainerStatusReason - InitContainerStatusMessage\n```\n```\n* containerStatusReason - containerStatusMessage\n```\n```\n* conditionReason - conditionMessage\n```")
+	outputString := fmt.Sprintf("*Rollout for Deployment `test` (RS: `test`) in `test` namespace failed after `10` seconds on the `` cluster.*\n\n*Retrieved the following errors:*\n```\n* containerStatusReason - containerStatusMessage\n```\n```\n* conditionReason - conditionMessage\n```\n```\n* InitContainerStatusReason - InitContainerStatusMessage\n```")
 	type args struct {
 		ctx           context.Context
 		namespace     string


### PR DESCRIPTION
Update deployment message to match the "rolling out" format where Namespace and the variable holding the namespace are the other way round.

This order change in the resulting slack messages bothers me more than it probably should.